### PR TITLE
use_pcap_time flag added

### DIFF
--- a/tram_segmentation/CMakeLists.txt
+++ b/tram_segmentation/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
   std_msgs
-  message_generation
+  ##message_generation
   pcl_conversions
   cv_bridge pcl_ros
 )

--- a/velodyne/README.md
+++ b/velodyne/README.md
@@ -3,6 +3,10 @@ roslaunch velodyne_pointcloud VLP16_points.launch pcap:=/home/ubuntu/bagfiles/tr
 
 
 
+**To use PCAP timestamps**, please use use_pcap_time flag:
+roslaunch velodyne_pointcloud VLP16_points.launch pcap:=/home/ubuntu/bagfiles/trm.052. play_season:=true start:=5 end:=12 use_pcap_time:="True"
+
+
 
 Overview
 ========

--- a/velodyne/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne/velodyne_driver/include/velodyne_driver/input.h
@@ -103,6 +103,7 @@ namespace velodyne_driver
               bool read_once=false,
               bool read_fast=false,
               double repeat_delay=0.0,
+              bool use_pcap_time=false,
               bool play_season_=false,
               int start=1,
               int end=999);
@@ -126,6 +127,7 @@ namespace velodyne_driver
     int start_;
     int end_;
     int episode;
+    bool use_pcap_time_;
   };
 
 } // velodyne_driver namespace

--- a/velodyne/velodyne_driver/launch/nodelet_manager.launch
+++ b/velodyne/velodyne_driver/launch/nodelet_manager.launch
@@ -12,6 +12,7 @@
   <arg name="read_fast" default="false" />
   <arg name="read_once" default="false" />
   <arg name="repeat_delay" default="0.0" />
+  <arg name="use_pcap_time" default="false"/>
   <arg name="rpm" default="600.0" />
   <arg name="cut_angle" default="-0.01" />
   <arg name="play_season" default="false" />
@@ -32,6 +33,7 @@
     <param name="read_fast" value="$(arg read_fast)"/>
     <param name="read_once" value="$(arg read_once)"/>
     <param name="repeat_delay" value="$(arg repeat_delay)"/>
+    <param name="use_pcap_time" value="$(arg use_pcap_time)"/>
     <param name="rpm" value="$(arg rpm)"/>
     <param name="cut_angle" value="$(arg cut_angle)"/>
     <param name="play_season" value="$(arg play_season)" />

--- a/velodyne/velodyne_driver/mainpage.dox
+++ b/velodyne/velodyne_driver/mainpage.dox
@@ -45,6 +45,7 @@ Parameters:
    possible (default false).
  - \b ~input/repeat_delay (double): number of seconds to delay before
    repeating input file (default: 0.0).
+ - \b ~input/use_pcap_time (bool): if true, use PCAP time (default false).
 
 \section vdump_command Vdump Command
 

--- a/velodyne/velodyne_pointcloud/launch/VLP16_points.launch
+++ b/velodyne/velodyne_pointcloud/launch/VLP16_points.launch
@@ -14,6 +14,7 @@
   <arg name="port" default="2368" />
   <arg name="read_fast" default="false" />
   <arg name="read_once" default="false" />
+  <arg name="use_pcap_time" default="false"/>
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="cut_angle" default="-0.01" />
@@ -33,6 +34,7 @@
     <arg name="port" value="$(arg port)"/>
     <arg name="read_fast" value="$(arg read_fast)"/>
     <arg name="read_once" value="$(arg read_once)"/>
+    <arg name="use_pcap_time" value="$(arg use_pcap_time)"/>
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>


### PR DESCRIPTION
PR резолвит  issue #2
теперь можно поставить флаг use_pcap_time:="True" чтобы velodyne_driver начал проставлять timestamp для velodyne_points, которые записанны внутри самого pcap файла